### PR TITLE
feat: add more css

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,24 @@
 }
 
 @layer components {
+  /* gradient animation for title */
+  .animate-gradient {
+    animation: gradient 3s linear infinite;
+  }
+
+  .title-gradient {
+    @apply bg-[linear-gradient(to_right,#2563eb,#9333ea,#2563eb)] bg-[length:200%_auto];
+  }
+
+  @keyframes gradient {
+    0% {
+      background-position: 0% center;
+    }
+    100% {
+      background-position: 200% center;
+    }
+  }
+
   /* div parent style */
   .parent {
     @apply container mx-auto px-4 py-8;
@@ -18,13 +36,17 @@
   .page-btns {
     @apply bg-linear-to-r from-blue-500 to-purple-500 hover:from-blue-600 hover:to-purple-600 text-white
     dark:from-blue-600 dark:to-purple-600 dark:hover:from-blue-700 dark:hover:to-purple-700
-    shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 rounded-lg font-medium transition-all duration-200;
+      shadow-md hover:shadow-lg disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2 rounded-lg font-medium transition-all duration-200;
   }
 
   /* card style */
   .base-card {
     @apply bg-linear-to-br from-white/90 to-violet-50/90 dark:from-gray-800/90 dark:to-blue-900/90 border
     border-white/20 dark:border-blue-900/20 rounded-lg backdrop-blur-sm transition-all;
+  }
+
+  .base-card-title-text {
+    @apply bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent;
   }
 
   /* button style */
@@ -34,5 +56,26 @@
   }
   .base-btn-on {
     @apply hover:scale-x-105 bg-linear-to-r from-blue-500 to-purple-500 text-white font-medium shadow-md shadow-blue-500/20 dark:shadow-purple-500/20;
+  }
+
+  /* role badge style */
+  .role-badge {
+    @apply inline-block rounded bg-linear-to-r from-blue-100/80 to-purple-100/80 dark:from-blue-800/90 dark:to-purple-800/90
+    text-blue-800 dark:text-blue-100 backdrop-blur-sm border border-blue-200/20 dark:border-blue-400/20;
+  }
+
+  /* lane badge style */
+  .lane-badge {
+    @apply inline-block rounded bg-linear-to-r from-purple-100/80 to-pink-100/80 dark:from-purple-800/90 dark:to-pink-800/90
+    text-purple-800 dark:text-purple-100 backdrop-blur-sm border border-purple-200/20 dark:border-purple-400/20;
+  }
+
+  /* stats card small title style */
+  .stats-card-title {
+    @apply flex justify-between items-center p-2 rounded-md transition-all hover:bg-slate-50 dark:hover:bg-white/5;
+  }
+
+  .stats-card-title-text {
+    @apply text-slate-600 dark:text-slate-300 group-hover/stat:text-blue-600 dark:group-hover/stat:text-white transition-colors;
   }
 }

--- a/src/components/ChampionCards/ChampionCard.tsx
+++ b/src/components/ChampionCards/ChampionCard.tsx
@@ -39,7 +39,7 @@ export const ChampionCard = ({ champion }: ChampionCardProps) => {
           {champion.roles.map(role => (
             <span
               key={role}
-              className="inline-block rounded bg-linear-to-r from-blue-100/80 to-purple-100/80 dark:from-blue-800/90 dark:to-purple-800/90 px-2 py-1 text-xs font-medium text-blue-800 dark:text-blue-100 backdrop-blur-sm border border-blue-200/20 dark:border-blue-400/20"
+              className="role-badge px-2 py-1 text-xs font-medium"
             >
               {roleLabels[role]}
             </span>

--- a/src/components/ChampionCards/ChampionFilterAndSort.tsx
+++ b/src/components/ChampionCards/ChampionFilterAndSort.tsx
@@ -59,12 +59,12 @@ export function ChampionFilterAndSort({
   };
 
   return (
-    <div className="base-card p-4 shadow-md space-y-6">
+    <div className="base-card py-4 shadow-md space-y-6">
       {/* Role Filter Section */}
       <div>
         <button
           onClick={() => setIsRolesOpen(!isRolesOpen)}
-          className="w-full flex justify-between items-center text-left"
+          className="w-full flex justify-between items-center text-left px-4"
         >
           <div className="flex items-center gap-2">
             <UserGroupIcon className="w-6 h-6 text-blue-500 dark:text-blue-300" />
@@ -87,7 +87,7 @@ export function ChampionFilterAndSort({
           className={`mt-4 transition-all duration-200 overflow-hidden
           ${isRolesOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}
         >
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2 px-4">
             {roles.map(role => (
               <button
                 key={role}
@@ -113,7 +113,7 @@ export function ChampionFilterAndSort({
       <div>
         <button
           onClick={() => setIsLanesOpen(!isLanesOpen)}
-          className="w-full flex justify-between items-center text-left"
+          className="w-full flex justify-between items-center text-left px-4"
         >
           <div className="flex items-center gap-2">
             <MapIcon className="w-6 h-6 text-blue-500 dark:text-blue-300" />
@@ -136,7 +136,7 @@ export function ChampionFilterAndSort({
           className={`mt-4 transition-all duration-200 overflow-hidden
           ${isLanesOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}
         >
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2 px-4">
             {lanes.map(lane => (
               <button
                 key={lane}
@@ -162,7 +162,7 @@ export function ChampionFilterAndSort({
       <div>
         <button
           onClick={() => setIsSortOpen(!isSortOpen)}
-          className="w-full flex justify-between items-center text-left"
+          className="w-full flex justify-between items-center text-left px-4"
         >
           <div className="flex items-center gap-2">
             <AdjustmentsHorizontalIcon className="w-6 h-6 text-blue-500 dark:text-blue-300" />
@@ -183,7 +183,7 @@ export function ChampionFilterAndSort({
           className={`mt-4 transition-all duration-200 overflow-hidden
           ${isSortOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}
         >
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap gap-2 px-4">
             {sortOptions.map(option => (
               <button
                 key={option.value}

--- a/src/components/ChampionDetail/ChampionBasicInfo.tsx
+++ b/src/components/ChampionDetail/ChampionBasicInfo.tsx
@@ -27,7 +27,7 @@ export const ChampionBasicInfo = memo(function ChampionBasicInfo({
     <div className="grid gap-6 md:grid-cols-2">
       {/* Description Card */}
       <div className="base-card p-6 duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5">
-        <h2 className="text-xl font-semibold bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent">
+        <h2 className="text-xl font-semibold base-card-title-text">
           チャンピオン説明
         </h2>
         <p className="mt-4 leading-relaxed text-slate-700 dark:text-slate-300">
@@ -39,7 +39,7 @@ export const ChampionBasicInfo = memo(function ChampionBasicInfo({
       <div className="space-y-4">
         {/* Champion Stats */}
         <div className="base-card p-6 duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5">
-          <h2 className="text-xl font-semibold bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent mb-4">
+          <h2 className="text-xl font-semibold base-card-title-text mb-4">
             チャンピオンのステータス
           </h2>
 
@@ -111,7 +111,7 @@ export const ChampionBasicInfo = memo(function ChampionBasicInfo({
           <div className="base-card p-6 duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5">
             <div className="flex items-center gap-3">
               <span className="text-2xl">⭐</span>
-              <span className="bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent font-medium">
+              <span className="base-card-title-text font-medium">
                 今週のフリーチャンピオンです！
               </span>
             </div>

--- a/src/components/ChampionDetail/ChampionStats.tsx
+++ b/src/components/ChampionDetail/ChampionStats.tsx
@@ -20,9 +20,7 @@ export const ChampionStats = memo(function ChampionStats({
   if (!stats || Object.keys(stats).length === 0) {
     return (
       <div className="mt-8">
-        <h2 className="text-xl font-semibold bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent">
-          統計情報
-        </h2>
+        <h2 className="text-xl font-semibold base-card-title-text">統計情報</h2>
         <p className="mt-4 text-slate-700 dark:text-slate-300">
           このチャンピオンの統計情報はありません。
         </p>
@@ -35,9 +33,7 @@ export const ChampionStats = memo(function ChampionStats({
 
   return (
     <div className="mt-8">
-      <h2 className="text-2xl font-bold bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent">
-        統計情報
-      </h2>
+      <h2 className="text-2xl font-bold base-card-title-text">統計情報</h2>
 
       {/* Rank Filter Card */}
       <div className="base-card mt-4 rounded-lg py-4 duration-300 shadow-lg shadow-blue-500/5">
@@ -75,7 +71,7 @@ export const ChampionStats = memo(function ChampionStats({
                   key={lane}
                   className="base-card group rounded-lg p-6 duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5"
                 >
-                  <h3 className="text-lg font-medium bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent group-hover:to-blue-600 dark:group-hover:to-blue-300 transition-all flex items-center justify-between">
+                  <h3 className="text-lg font-medium base-card-title-text group-hover:to-blue-600 dark:group-hover:to-blue-300 transition-all flex items-center justify-between">
                     <span>{laneDisplayNames[lane]}レーン</span>
                     <span className="text-xs text-gray-500 dark:text-gray-400 font-normal">
                       <CalendarIcon className="w-3.5 h-3.5 inline-block mr-1 mb-1" />
@@ -86,9 +82,7 @@ export const ChampionStats = memo(function ChampionStats({
                   <div className="mt-4 space-y-4">
                     {/* Win Rate */}
                     <div className="group/stat flex justify-between items-center p-2 rounded-md transition-all hover:bg-slate-50 dark:hover:bg-white/5">
-                      <span className="text-slate-600 dark:text-slate-300 group-hover/stat:text-blue-600 dark:group-hover/stat:text-white transition-colors">
-                        勝率
-                      </span>
+                      <span className="stats-card-title-text">勝率</span>
                       <span
                         className={`font-medium ${getWinRateColor(parseFloat(laneStats.win_rate_percent))} group-hover/stat:scale-110 transition-transform`}
                       >
@@ -97,20 +91,16 @@ export const ChampionStats = memo(function ChampionStats({
                     </div>
 
                     {/* Pick Rate */}
-                    <div className="group/stat flex justify-between items-center p-2 rounded-md transition-all hover:bg-slate-50 dark:hover:bg-white/5">
-                      <span className="text-slate-600 dark:text-slate-300 group-hover/stat:text-blue-600 dark:group-hover/stat:text-white transition-colors">
-                        ピック率
-                      </span>
+                    <div className="group/stat stats-card-title">
+                      <span className="stats-card-title-text">ピック率</span>
                       <span className="font-medium text-blue-600 dark:text-blue-300 group-hover/stat:scale-110 transition-transform">
                         {laneStats.appear_rate_percent}%
                       </span>
                     </div>
 
                     {/* Ban Rate */}
-                    <div className="group/stat flex justify-between items-center p-2 rounded-md transition-all hover:bg-slate-50 dark:hover:bg-white/5">
-                      <span className="text-slate-600 dark:text-slate-300 group-hover/stat:text-blue-600 dark:group-hover/stat:text-white transition-colors">
-                        バン率
-                      </span>
+                    <div className="group/stat stats-card-title">
+                      <span className="stats-card-title-text">バン率</span>
                       <span className="font-medium text-blue-600 dark:text-purple-300 group-hover/stat:scale-110 transition-transform">
                         {laneStats.forbid_rate_percent}%
                       </span>
@@ -118,10 +108,8 @@ export const ChampionStats = memo(function ChampionStats({
 
                     {/* Strength Index */}
                     <div className="mt-2 pt-2 border-t border-slate-200/50 dark:border-white/10">
-                      <div className="group/stat flex justify-between items-center p-2 rounded-md transition-all hover:bg-slate-50 dark:hover:bg-white/5">
-                        <span className="text-slate-600 dark:text-slate-300 group-hover/stat:text-blue-600 dark:group-hover/stat:text-white transition-colors">
-                          強さ指数
-                        </span>
+                      <div className="group/stat stats-card-title">
+                        <span className="stats-card-title-text">強さ指数</span>
                         <span
                           className={`font-medium ${getStrengthColor(parseInt(laneStats.strength, 10))} group-hover/stat:scale-110 transition-transform`}
                         >

--- a/src/components/ChampionDetail/ChampionStats.tsx
+++ b/src/components/ChampionDetail/ChampionStats.tsx
@@ -40,17 +40,14 @@ export const ChampionStats = memo(function ChampionStats({
       </h2>
 
       {/* Rank Filter Card */}
-      <div
-        className="mt-4 rounded-lg bg-linear-to-br from-white/90 to-blue-50/90 dark:from-gray-800/90 dark:to-blue-900/80 
-        p-4 backdrop-blur-sm border border-white/20 dark:border-blue-900/20 transition-all duration-300 shadow-lg shadow-blue-500/5"
-      >
-        <div className="flex gap-2 overflow-x-auto pb-2">
+      <div className="base-card mt-4 rounded-lg py-4 duration-300 shadow-lg shadow-blue-500/5">
+        <div className="flex gap-2 overflow-x-auto pb-2 px-4">
           {(Object.keys(rankDisplayNames) as RankRange[]).map(rank => (
             <button
               key={rank}
               onClick={() => setSelectedRank(rank)}
               className={`whitespace-nowrap rounded-lg px-4 py-2 text-sm font-medium transition-all duration-300 ${
-                selectedRank === rank ? 'base-btn-off' : 'base-btn-on'
+                selectedRank === rank ? 'base-btn-on' : 'base-btn-off'
               }`}
             >
               {rankDisplayNames[rank]}
@@ -62,10 +59,7 @@ export const ChampionStats = memo(function ChampionStats({
       {/* Stats Grid */}
       <div className="mt-6">
         {lanes.length === 0 ? (
-          <div
-            className="rounded-lg bg-linear-to-br from-white/90 to-blue-50/90 dark:from-gray-800/90 dark:to-blue-900/80 
-            p-6 backdrop-blur-sm border border-white/20 dark:border-blue-900/20 transition-all duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5"
-          >
+          <div className="base-card rounded-lg p-6 duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5">
             <p className="text-slate-700 dark:text-slate-300">
               このランクでの統計情報はありません。
             </p>
@@ -79,8 +73,7 @@ export const ChampionStats = memo(function ChampionStats({
               return (
                 <div
                   key={lane}
-                  className="group rounded-lg bg-linear-to-br from-white/90 to-blue-50/90 dark:from-gray-800/90 dark:to-blue-900/80 
-                  p-6 backdrop-blur-sm border border-white/20 dark:border-blue-900/20 transition-all duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5"
+                  className="base-card group rounded-lg p-6 duration-300 hover:border-blue-300/50 dark:hover:border-blue-500/30 shadow-lg shadow-blue-500/5"
                 >
                   <h3 className="text-lg font-medium bg-linear-to-r from-blue-600 to-blue-800 dark:from-white dark:to-blue-200 bg-clip-text text-transparent group-hover:to-blue-600 dark:group-hover:to-blue-300 transition-all flex items-center justify-between">
                     <span>{laneDisplayNames[lane]}レーン</span>

--- a/src/components/ChampionDetail/index.tsx
+++ b/src/components/ChampionDetail/index.tsx
@@ -200,7 +200,7 @@ export function ChampionDetailContainer({
                   {champion.roles.map(role => (
                     <span
                       key={role}
-                      className="inline-block rounded bg-linear-to-r from-blue-100/80 to-indigo-100/80 dark:from-blue-800/90 dark:to-indigo-800/90 px-3 py-1.5 text-sm font-medium text-blue-800 dark:text-blue-100 backdrop-blur-sm border border-blue-200/20 dark:border-blue-400/20"
+                      className="role-badge px-3 py-1.5 text-sm font-medium"
                     >
                       {roleLabels[role]}
                     </span>
@@ -212,7 +212,7 @@ export function ChampionDetailContainer({
                   {champion.lanes.map(lane => (
                     <span
                       key={lane}
-                      className="inline-block rounded bg-linear-to-r from-purple-100/80 to-pink-100/80 dark:from-purple-800/90 dark:to-pink-800/90 px-3 py-1.5 text-sm font-medium text-purple-800 dark:text-purple-100 backdrop-blur-sm border border-purple-200/20 dark:border-purple-400/20"
+                      className="lane-badge px-3 py-1.5 text-sm font-medium "
                     >
                       {laneLabels[lane]}
                     </span>

--- a/src/components/home/Title.tsx
+++ b/src/components/home/Title.tsx
@@ -4,9 +4,11 @@ export default function Title() {
   return (
     <section className="relative py-20 px-4 sm:px-6 lg:px-8">
       <div className="container mx-auto text-center">
-        <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-transparent bg-clip-text bg-linear-to-r from-blue-600 to-purple-600 mb-6">
-          Wild Rift Stats
-        </h1>
+        <div className="flex justify-center">
+          <h1 className="text-4xl sm:text-5xl md:text-6xl font-bold text-transparent bg-clip-text mb-6 animate-gradient title-gradient">
+            Wild Rift Stats
+          </h1>
+        </div>
         <p className="text-xl text-gray-600 dark:text-gray-300 mb-8">
           チャンピオンの統計データを分析して、最適な戦略を見つけよう
         </p>

--- a/src/components/stats/LaneFilter.tsx
+++ b/src/components/stats/LaneFilter.tsx
@@ -29,10 +29,10 @@ export const LaneFilter: FC<LaneFilterProps> = ({
   lanes,
 }) => {
   return (
-    <div className="border-t border-gray-200/20 dark:border-gray-700/20 pt-6">
+    <div className="pt-6">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex justify-between items-center text-left"
+        className="w-full flex justify-between items-center text-left px-4"
       >
         <div className="flex items-center gap-2">
           <MapIcon className="w-6 h-6 text-blue-500 dark:text-blue-300" />
@@ -53,7 +53,7 @@ export const LaneFilter: FC<LaneFilterProps> = ({
         className={`mt-4 transition-all duration-200 overflow-hidden
         ${isOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}
       >
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 px-4">
           {lanes.map(lane => (
             <button
               key={lane}

--- a/src/components/stats/RankFilter.tsx
+++ b/src/components/stats/RankFilter.tsx
@@ -29,7 +29,7 @@ export const RankFilter: FC<RankFilterProps> = ({
     <div>
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="w-full flex justify-between items-center text-left"
+        className="w-full flex justify-between items-center text-left px-4"
       >
         <div className="flex items-center gap-2">
           <GlobeAltIcon className="w-6 h-6 text-blue-500 dark:text-blue-300" />
@@ -47,7 +47,7 @@ export const RankFilter: FC<RankFilterProps> = ({
       <div
         className={`mt-4 transition-all duration-200 overflow-hidden ${isOpen ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'}`}
       >
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2 px-4">
           {' '}
           {Object.entries(rankDisplayNames).map(([rank, name]) => (
             <button

--- a/src/components/stats/index.tsx
+++ b/src/components/stats/index.tsx
@@ -132,7 +132,7 @@ export function StatsMatrix() {
     <div className="parent">
       <div className="space-y-8">
         {/* Combined Filter Section */}
-        <div className="base-card p-4 shadow-md space-y-2">
+        <div className="base-card py-4 shadow-md space-y-2">
           {/* Rank Filter */}
           <RankFilter
             currentRank={actualRank}


### PR DESCRIPTION
This pull request introduces a series of CSS refactors and enhancements to improve maintainability and visual consistency across components. Key changes include the addition of reusable utility classes for gradients, badges, and card titles, as well as adjustments to padding and layout for better spacing.

### CSS Refactors and Utility Classes:
* Added reusable utility classes: `animate-gradient`, `title-gradient`, `base-card-title-text`, `role-badge`, `lane-badge`, and `stats-card-title-text` for consistent styling of gradients, badges, and card titles in `src/app/globals.css`. [[1]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R12-R29) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R48-R51) [[3]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412R60-R80)

### Component Updates for Reusability:
* Replaced inline styles with new utility classes (`role-badge`, `lane-badge`, `base-card-title-text`, etc.) in components like `ChampionCard`, `ChampionDetailContainer`, `ChampionBasicInfo`, and `ChampionStats` for improved consistency. [[1]](diffhunk://#diff-de330b72c0e45bc2b284cbf089643dd5a8b415ea04c63a6b072d0d2bc19fd8a1L42-R42) [[2]](diffhunk://#diff-166621972f49aab6bf34b2292257c2bb58a61c8a72fcd06c72943dd66c813df4L203-R203) [[3]](diffhunk://#diff-242fe17f203286ee18ed23d08edf84fa1587fba170556c91bd1d9e3ab1e90427L30-R30) [[4]](diffhunk://#diff-c9a3e3a57612d0ba61333ea4eecd66ae0d6b1b9706c18237b9fa991a21e4826eL23-R23)

### Layout and Spacing Adjustments:
* Added consistent padding (`px-4`) to filter and sort sections in `ChampionFilterAndSort` and `LaneFilter` for better alignment and spacing. [[1]](diffhunk://#diff-8213cdb8f986746340da867af6af96dba1304f974c7e6c21f97964834aa88cf3L62-R67) [[2]](diffhunk://#diff-b590b05744845ea4a9d06638e6452fd803a7631b9181053024ab4b76f31511a4L32-R35)

### Animation Enhancements:
* Introduced a gradient animation (`animate-gradient`) for the title in the `Title` component, enhancing visual appeal.

### Simplified Card Styles:
* Replaced repetitive card styles with the `base-card` class in `ChampionStats` to reduce redundancy and streamline updates. [[1]](diffhunk://#diff-c9a3e3a57612d0ba61333ea4eecd66ae0d6b1b9706c18237b9fa991a21e4826eL38-R46) [[2]](diffhunk://#diff-c9a3e3a57612d0ba61333ea4eecd66ae0d6b1b9706c18237b9fa991a21e4826eL65-R58)